### PR TITLE
Support files that have a query in the file name.

### DIFF
--- a/packages/utils/src/webpack/extract/__tests__/assets.js
+++ b/packages/utils/src/webpack/extract/__tests__/assets.js
@@ -125,4 +125,82 @@ describe('Webpack/extract/assets', () => {
 
     expect(actual).toEqual(expected);
   });
+
+  test('should return metrics when a query is in the file name', () => {
+    const actual = extractAssets({
+      assets: [
+        {
+          name: 'js/main.bc22113.js?test=abcd',
+          size: 100,
+        },
+        {
+          name: 'css/app.22929ab.css?test=abcd',
+          size: 100,
+        },
+        {
+          name: 'css/app.22929ab.css.map',
+          size: 100,
+        },
+        {
+          name: 'img/logo.1211a12.png?test=abcd&test2=dcba',
+          size: 10,
+        },
+        {
+          name: 'js/main.bc22113.LICENSE.txt',
+          size: 10,
+        },
+      ],
+      chunks: [
+        {
+          entry: true,
+          id: 1,
+          initial: true,
+          files: ['js/main.bc22113.js?test=abcd'],
+          names: ['main'],
+        },
+        {
+          entry: false,
+          id: 2,
+          initial: false,
+          files: ['css/app.22929ab.css?test=abcd'],
+          names: ['app'],
+        },
+      ],
+      entrypoints: {
+        main: {
+          assets: ['js/main.bc22113.js?test=abcd'],
+        },
+      },
+    });
+
+    const expected = {
+      metrics: {
+        assets: {
+          'js/main.js': {
+            name: 'js/main.bc22113.js',
+            value: 100,
+            isEntry: true,
+            isInitial: true,
+            isChunk: false,
+          },
+          'css/app.css': {
+            name: 'css/app.22929ab.css',
+            value: 100,
+            isEntry: false,
+            isInitial: false,
+            isChunk: true,
+          },
+          'img/logo.png': {
+            name: 'img/logo.1211a12.png',
+            value: 10,
+            isEntry: false,
+            isInitial: false,
+            isChunk: false,
+          },
+        },
+      },
+    };
+
+    expect(actual).toEqual(expected);
+  });
 });

--- a/packages/utils/src/webpack/extract/assets.js
+++ b/packages/utils/src/webpack/extract/assets.js
@@ -24,13 +24,13 @@ export const extractAssets = (webpackStats) => {
     .flat();
 
   const assets = webpackAssets.reduce((aggregator, asset) => {
-    asset.name = asset.name && asset.name.split('?')[0];
+    const baseName = asset.name && asset.name.split('?')[0];
 
-    if (IGNORE_PATTERN.test(asset.name)) {
+    if (IGNORE_PATTERN.test(baseName)) {
       return aggregator;
     }
 
-    const source = getAssetName(asset.name);
+    const source = getAssetName(baseName);
     // @TODO Get an uniq id (based on url, source)
     const id = source;
 
@@ -39,7 +39,7 @@ export const extractAssets = (webpackStats) => {
     return {
       ...aggregator,
       [id]: {
-        name,
+        name: baseName,
         value: size,
         isEntry: entryItems.includes(name),
         isInitial: initialItems.includes(name),

--- a/packages/utils/src/webpack/extract/assets.js
+++ b/packages/utils/src/webpack/extract/assets.js
@@ -24,6 +24,8 @@ export const extractAssets = (webpackStats) => {
     .flat();
 
   const assets = webpackAssets.reduce((aggregator, asset) => {
+    asset.name = asset.name && asset.name.split('?')[0];
+
     if (IGNORE_PATTERN.test(asset.name)) {
       return aggregator;
     }


### PR DESCRIPTION
Removes the query from the file name. Allows for files name :

72589901332095ed3ff1.theme.css?sha384 -> 72589901332095ed3ff1.theme.css
theme.72589901332095ed3ff1.css?sha384 -> theme.css
main.72589901332095ed3ff1.bundle.js?sha384 -> main.bundle.js

fixed #1164