### PR TITLE
feat: add an option to only log error/warning and stop logging info

### DIFF
--- a/packages/webpack-plugin/README.md
+++ b/packages/webpack-plugin/README.md
@@ -63,6 +63,7 @@ module.exports = {
 - `html` - output html report (default `true`).
 - `json` - output json report (default `false`).
 - `outDir` - output directory relative to webpack `output.path` (default `''`).
+- `silent` - stop logging info and only log warning and error (default `false`).
 - `stats` - [Webpack stats](https://webpack.js.org/configuration/stats) options
   default:
   ```js

--- a/packages/webpack-plugin/src/webpack-plugin.js
+++ b/packages/webpack-plugin/src/webpack-plugin.js
@@ -20,6 +20,7 @@ const DEFAULT_OPTIONS = {
   html: true,
   json: false,
   outDir: '',
+  silent: false,
   stats: {
     context: process.cwd(),
     assets: true,
@@ -65,7 +66,7 @@ const generateReports = async (compilation, options) => {
     if (compare) {
       baselineStats = await readBaseline();
       baselineStats = filter(baselineStats);
-      logger.info(`Read baseline from ${baselineFilepath}`);
+      if (!options.silent) logger.info(`Read baseline from ${baselineFilepath}`);
     }
   } catch (err) {
     logger.warn(TEXT.PLUGIN_BASELINE_MISSING_WARN);
@@ -86,12 +87,12 @@ const generateReports = async (compilation, options) => {
     // eslint-disable-next-line no-param-reassign
     newAssets[baselineFilepath] = JSON.stringify(data);
 
-    logger.info(`Write baseline data to ${baselineFilepath}`);
+    if (!options.silent) logger.info(`Write baseline data to ${baselineFilepath}`);
   }
 
   const info = getReportInfo(report);
 
-  if (info) {
+  if (info && !options.silent) {
     logger.info(info.text);
   }
 


### PR DESCRIPTION
Relate to [Feature Request for webpack plugin : new option to disable bundle-stats logger](https://github.com/relative-ci/bundle-stats/issues/1256)