### PR TITLE
adding apply method to BundleStatsWebpackPlugin to plugin typings.d.ts

### DIFF
--- a/packages/webpack-plugin/typings.d.ts
+++ b/packages/webpack-plugin/typings.d.ts
@@ -1,5 +1,7 @@
 export class BundleStatsWebpackPlugin {
   constructor(options?: Partial<BundleStatsWebpackPlugin.Options>) {}
+
+  apply(compiler: Compiler): void;
 };
 
 declare namespace BundleStatsWebpackPlugin {


### PR DESCRIPTION
Webpack requires for plugins to implement the apply `apply(compiler)` method.

bundle-stats does have that method implemented in `webpack-plugin.js` but the method is missing in `typing.d.ts` declaration file.

As a result, the attempt to use `bundle-stats` in the following way will fail and will show TS errors.

```
import { BundleStatsWebpackPlugin } from 'bundle-stats-webpack-plugin';
....
plugins: [
            new BundleStatsWebpackPlugin({ ... }),
            ...
 ]
```

Currently, trying to use bundle-stats in the following manner will throw an error saying `Property 'apply' is missing in type 'BundleStatsWebpackPlugin' but required in type 'WebpackPluginInstance'.` 