### PR TITLE
feat: Base asset.isEntry on chunks[].entry

### DIFF
--- a/fixtures/job.baseline.json
+++ b/fixtures/job.baseline.json
@@ -85,20 +85,6 @@
           "size": 48381
         }
       ],
-      "entrypoints": {
-        "main": {
-          "assets": [
-            "vendors.8b6bb4f.css",
-            "vendors.176a5f6.js",
-            "vendors.8b6bb4f.css.map",
-            "vendors.176a5f6.js.map",
-            "main.e7aed2d.css",
-            "main.75d52d9.js",
-            "main.e7aed2d.css.map",
-            "main.75d52d9.js.map"
-          ]
-        }
-      },
       "chunks": [
         {
           "id": 0,
@@ -116,7 +102,7 @@
         },
         {
           "id": 1,
-          "entry": false,
+          "entry": true,
           "initial": true,
           "files": [
             "vendors.8b6bb4f.css",

--- a/fixtures/job.current.json
+++ b/fixtures/job.current.json
@@ -117,20 +117,6 @@
           "size": 38673
         }
       ],
-      "entrypoints": {
-        "main": {
-          "assets": [
-            "vendors.5024abb.css",
-            "vendors.278dc2f.js",
-            "vendors.5024abb.css.map",
-            "vendors.278dc2f.js.map",
-            "main.12dd8b1.css",
-            "main.a0929a4.js",
-            "main.12dd8b1.css.map",
-            "main.a0929a4.js.map"
-          ]
-        }
-      },
       "chunks": [
         {
           "id": 0,
@@ -204,7 +190,7 @@
         },
         {
           "id": 5,
-          "entry": false,
+          "entry": true,
           "initial": true,
           "files": [
             "vendors.5024abb.css",

--- a/packages/cli-utils/__fixtures__/webpack-stats-baseline.json
+++ b/packages/cli-utils/__fixtures__/webpack-stats-baseline.json
@@ -79,20 +79,6 @@
       "size": 573665
     }
   ],
-  "entrypoints": {
-    "main": {
-      "assets": [
-        "1.010f5.css",
-        "vendor.ae130.js",
-        "1.010f5.css.map",
-        "vendor.ae130.js.map",
-        "main.df5df.css",
-        "main.bc8f2337.js",
-        "main.df5df.css.map",
-        "main.bc8f2337.js.map"
-      ]
-    }
-  },
   "chunks": [
     {
       "id": 0,
@@ -110,7 +96,7 @@
     },
     {
       "id": 1,
-      "entry": false,
+      "entry": true,
       "initial": true,
       "files": [
         "1.010f5.css",

--- a/packages/cli-utils/__fixtures__/webpack-stats-current.json
+++ b/packages/cli-utils/__fixtures__/webpack-stats-current.json
@@ -79,20 +79,6 @@
       "size": 573665
     }
   ],
-  "entrypoints": {
-    "main": {
-      "assets": [
-        "1.2428c.css",
-        "vendor.6858d.js",
-        "1.2428c.css.map",
-        "vendor.6858d.js.map",
-        "main.bd313.css",
-        "main.af1dbc34.js",
-        "main.bd313.css.map",
-        "main.af1dbc34.js.map"
-      ]
-    }
-  },
   "chunks": [
     {
       "id": 0,
@@ -110,7 +96,7 @@
     },
     {
       "id": 1,
-      "entry": false,
+      "entry": true,
       "initial": true,
       "files": [
         "1.2428c.css",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -61,7 +61,6 @@ The CLI is consuming the Webpack stats json. The following [stats options](https
 {
   stats: {
     assets: true,
-    entrypoints: true,
     chunks: true,
     modules: true,
     builtAt: true,

--- a/packages/cli/__fixtures__/webpack-stats-baseline.json
+++ b/packages/cli/__fixtures__/webpack-stats-baseline.json
@@ -74,20 +74,6 @@
       "size": 48381
     }
   ],
-  "entrypoints": {
-    "main": {
-      "assets": [
-        "vendors.8b6bb4f.css",
-        "vendors.176a5f6.js",
-        "vendors.8b6bb4f.css.map",
-        "vendors.176a5f6.js.map",
-        "main.e7aed2d.css",
-        "main.75d52d9.js",
-        "main.e7aed2d.css.map",
-        "main.75d52d9.js.map"
-      ]
-    }
-  },
   "chunks": [
     {
       "id": 0,
@@ -105,7 +91,7 @@
     },
     {
       "id": 1,
-      "entry": false,
+      "entry": true,
       "initial": true,
       "files": [
         "vendors.8b6bb4f.css",

--- a/packages/cli/__fixtures__/webpack-stats-current.json
+++ b/packages/cli/__fixtures__/webpack-stats-current.json
@@ -106,20 +106,6 @@
       "size": 38673
     }
   ],
-  "entrypoints": {
-    "main": {
-      "assets": [
-        "vendors.5024abb.css",
-        "vendors.278dc2f.js",
-        "vendors.5024abb.css.map",
-        "vendors.278dc2f.js.map",
-        "main.12dd8b1.css",
-        "main.a0929a4.js",
-        "main.12dd8b1.css.map",
-        "main.a0929a4.js.map"
-      ]
-    }
-  },
   "chunks": [
     {
       "id": 0,
@@ -193,7 +179,7 @@
     },
     {
       "id": 5,
-      "entry": false,
+      "entry": true,
       "initial": true,
       "files": [
         "vendors.5024abb.css",

--- a/packages/plugin-webpack-filter/src/index.ts
+++ b/packages/plugin-webpack-filter/src/index.ts
@@ -12,13 +12,6 @@ export interface WebpackStatsFilteredAsset {
   size?: number;
 }
 
-export interface WebpackStatsFilteredEntrypoint {
-  /** List of entrypoint assets. Webpack 5 provides an asset object */
-  assets: Array<WebpackStatsFilteredAsset | string>;
-}
-
-export type WebpackStatsFilteredEntrypoints = Record<string, WebpackStatsFilteredEntrypoint>;
-
 export interface WebpackStatsFilteredChunk {
   entry: boolean;
   id: number | string;
@@ -46,7 +39,6 @@ export interface WebpackStatsFiltered {
   builtAt?: number;
   hash?: string;
   assets?: Array<WebpackStatsFilteredAsset>;
-  entrypoints?: WebpackStatsFilteredEntrypoints;
   chunks?: Array<WebpackStatsFilteredChunk>;
   modules?: Array<WebpackStatsFilteredRootModule>;
 }
@@ -78,15 +70,6 @@ export default (
 
       return agg;
     }, [] as Array<WebpackStatsFilteredAsset>) || [];
-
-  const entrypoints = Object.entries(source?.entrypoints || {}).reduce((agg, [key, value]) => {
-    // eslint-disable-next-line no-param-reassign
-    agg[key] = {
-      assets: value.assets as Array<WebpackStatsFilteredAsset | string>,
-    };
-
-    return agg;
-  }, {} as WebpackStatsFilteredEntrypoints);
 
   const chunks =
     source.chunks?.reduce((agg, chunk) => {
@@ -147,7 +130,6 @@ export default (
     builtAt,
     hash,
     assets,
-    entrypoints,
     chunks,
     modules,
   };

--- a/packages/utils/__fixtures__/webpack-stats-1.extracted.js
+++ b/packages/utils/__fixtures__/webpack-stats-1.extracted.js
@@ -28,16 +28,6 @@ module.exports = {
       names: ['main'],
     },
   ],
-  entrypoints: {
-    main: {
-      assets: [
-        'main.a1b2c3d.css',
-        'main.a1b2c3d.css.map',
-        'main.a2b3c4d.js',
-        'main.a2b3c4d.js.map',
-      ],
-    },
-  },
   modules: [
     {
       chunks: [1],

--- a/packages/utils/__fixtures__/webpack-stats-1.js
+++ b/packages/utils/__fixtures__/webpack-stats-1.js
@@ -78,19 +78,6 @@ module.exports = {
       size: 0,
     },
   ],
-  entrypoints: {
-    main: {
-      assets: [
-        'main.a1b2c3d.css',
-        'main.a1b2c3d.css.map',
-        'main.a2b3c4d.js',
-        'main.a2b3c4d.js.map',
-      ],
-      childAssets: {},
-      children: {},
-      chunks: [1, 0],
-    },
-  },
   modules: [
     {
       assets: [],

--- a/packages/utils/__fixtures__/webpack-stats-2.extracted.js
+++ b/packages/utils/__fixtures__/webpack-stats-2.extracted.js
@@ -28,16 +28,6 @@ module.exports = {
       names: ['main'],
     },
   ],
-  entrypoints: {
-    main: {
-      assets: [
-        'main.b1c2d3e.css',
-        'main.b1c2d3e.css.map',
-        'main.b2c3d4e.js',
-        'main.b2c3d4e.js.map',
-      ],
-    },
-  },
   modules: [
     {
       chunks: [1],

--- a/packages/utils/__fixtures__/webpack-stats-2.js
+++ b/packages/utils/__fixtures__/webpack-stats-2.js
@@ -55,10 +55,7 @@ module.exports = {
       id: 1,
       initial: true,
       modules: [],
-      files: [
-        'main.css',
-        'main.js',
-      ],
+      files: ['main.css', 'main.js'],
       names: ['main'],
       origins: [],
       parents: [],
@@ -67,19 +64,6 @@ module.exports = {
       size: 60000,
     },
   ],
-  entrypoints: {
-    main: {
-      assets: [
-        'main.css',
-        'main.css.map',
-        'main.js',
-        'main.js.map',
-      ],
-      childAssets: {},
-      children: {},
-      chunks: [1, 0],
-    },
-  },
   modules: [
     {
       assets: [],

--- a/packages/utils/__fixtures__/webpack-stats-3.extracted.js
+++ b/packages/utils/__fixtures__/webpack-stats-3.extracted.js
@@ -28,16 +28,6 @@ module.exports = {
       names: ['main'],
     },
   ],
-  entrypoints: {
-    main: {
-      assets: [
-        'main.a1b2c3d.css',
-        'main.a1b2c3d.css.map',
-        'main.a2b3c4d.js',
-        'main.a2b3c4d.js.map',
-      ],
-    },
-  },
   modules: [
     {
       chunks: [1],

--- a/packages/utils/__fixtures__/webpack-stats-3.js
+++ b/packages/utils/__fixtures__/webpack-stats-3.js
@@ -78,19 +78,6 @@ module.exports = {
       size: 0,
     },
   ],
-  entrypoints: {
-    main: {
-      assets: [
-        'main.a1b2c3d.css',
-        'main.a1b2c3d.css.map',
-        'main.a2b3c4d.js',
-        'main.a2b3c4d.js.map',
-      ],
-      childAssets: {},
-      children: {},
-      chunks: [1, 0],
-    },
-  },
   modules: [
     {
       assets: [],

--- a/packages/utils/src/jobs/__tests__/__snapshots__/create-job.js.snap
+++ b/packages/utils/src/jobs/__tests__/__snapshots__/create-job.js.snap
@@ -242,16 +242,6 @@ Object {
           ],
         },
       ],
-      "entrypoints": Object {
-        "main": Object {
-          "assets": Array [
-            "main.a1b2c3d.css",
-            "main.a1b2c3d.css.map",
-            "main.a2b3c4d.js",
-            "main.a2b3c4d.js.map",
-          ],
-        },
-      },
       "hash": "abcd1234",
       "modules": Array [
         Object {
@@ -597,16 +587,6 @@ Object {
           ],
         },
       ],
-      "entrypoints": Object {
-        "main": Object {
-          "assets": Array [
-            "main.a1b2c3d.css",
-            "main.a1b2c3d.css.map",
-            "main.a2b3c4d.js",
-            "main.a2b3c4d.js.map",
-          ],
-        },
-      },
       "hash": "abcd1234",
       "modules": Array [
         Object {

--- a/packages/utils/src/webpack/extract/__tests__/assets.ts
+++ b/packages/utils/src/webpack/extract/__tests__/assets.ts
@@ -46,11 +46,6 @@ describe('Webpack/extract/assets', () => {
           names: ['app'],
         },
       ],
-      entrypoints: {
-        main: {
-          assets: ['js/main.bc22113.js'],
-        },
-      },
     });
 
     const expected = {
@@ -115,11 +110,6 @@ describe('Webpack/extract/assets', () => {
           names: ['main'],
         },
       ],
-      entrypoints: {
-        main: {
-          assets: [{ name: 'js/main.bc22113.js' }],
-        },
-      },
     });
 
     const expected = {
@@ -148,7 +138,7 @@ describe('Webpack/extract/assets', () => {
     expect(actual).toEqual(expected);
   });
 
-  test('should return metrics when chunks and entrypoints are missing', () => {
+  test('should return metrics when chunks are missing', () => {
     const actual = extractAssets({
       assets: [
         {
@@ -230,11 +220,6 @@ describe('Webpack/extract/assets', () => {
           names: ['app'],
         },
       ],
-      entrypoints: {
-        main: {
-          assets: ['js/main.bc22113.js?test=abcd'],
-        },
-      },
     });
 
     const expected = {

--- a/packages/webpack-plugin/README.md
+++ b/packages/webpack-plugin/README.md
@@ -69,7 +69,6 @@ module.exports = {
   {
     stats: {
       assets: true,
-      entrypoints: true,
       chunks: true,
       modules: true,
       builtAt: true,

--- a/packages/webpack-plugin/__fixtures__/webpack-stats-baseline.json
+++ b/packages/webpack-plugin/__fixtures__/webpack-stats-baseline.json
@@ -79,20 +79,6 @@
       "size": 573665
     }
   ],
-  "entrypoints": {
-    "main": {
-      "assets": [
-        "1.010f5.css",
-        "vendor.ae130.js",
-        "1.010f5.css.map",
-        "vendor.ae130.js.map",
-        "main.df5df.css",
-        "main.bc8f2337.js",
-        "main.df5df.css.map",
-        "main.bc8f2337.js.map"
-      ]
-    }
-  },
   "chunks": [
     {
       "id": 0,
@@ -110,7 +96,7 @@
     },
     {
       "id": 1,
-      "entry": false,
+      "entry": true,
       "initial": true,
       "files": [
         "1.010f5.css",

--- a/packages/webpack-plugin/__fixtures__/webpack-stats-current.json
+++ b/packages/webpack-plugin/__fixtures__/webpack-stats-current.json
@@ -79,20 +79,6 @@
       "size": 573665
     }
   ],
-  "entrypoints": {
-    "main": {
-      "assets": [
-        "1.2428c.css",
-        "vendor.6858d.js",
-        "1.2428c.css.map",
-        "vendor.6858d.js.map",
-        "main.bd313.css",
-        "main.af1dbc34.js",
-        "main.bd313.css.map",
-        "main.af1dbc34.js.map"
-      ]
-    }
-  },
   "chunks": [
     {
       "id": 0,
@@ -110,7 +96,7 @@
     },
     {
       "id": 1,
-      "entry": false,
+      "entry": true,
       "initial": true,
       "files": [
         "1.2428c.css",

--- a/packages/webpack-plugin/src/webpack-plugin.js
+++ b/packages/webpack-plugin/src/webpack-plugin.js
@@ -23,7 +23,6 @@ const DEFAULT_OPTIONS = {
   silent: false,
   stats: {
     assets: true,
-    entrypoints: true,
     chunks: true,
     modules: true,
     hash: true,

--- a/packages/webpack-plugin/typings.d.ts
+++ b/packages/webpack-plugin/typings.d.ts
@@ -13,12 +13,6 @@ declare namespace BundleStatsWebpackPlugin {
     assets?: Boolean;
 
     /**
-     * Output webpack entrypoints information
-     * Default: `true`.
-     */
-    entrypoints?: Boolean;
-
-    /**
      * Output webpack chunks information
      * Default: `true`.
      */
@@ -76,8 +70,8 @@ declare namespace BundleStatsWebpackPlugin {
 
     /**
      * webpack stats options
-     * Default: `{ assets: true, entrypoints: true, chunks: true, modules: true, hash: true, builtAt: true }`.
+     * Default: `{ assets: true: true, chunks: true, modules: true, hash: true, builtAt: true }`.
      */
-    stats?: Partial<WebpackStatsOptions>
+    stats?: Partial<WebpackStatsOptions>;
   }
 }


### PR DESCRIPTION
BREAKING: Skip extracting .entrypoints data

close: https://github.com/relative-ci/bundle-stats/issues/2179