### PR TITLE
Fix empty baseline

### DIFF
--- a/packages/ui/src/components/bundle-modules/bundle-modules.utils.js
+++ b/packages/ui/src/components/bundle-modules/bundle-modules.utils.js
@@ -87,7 +87,7 @@ export const useModuleFilterByChunk = ({ jobs, filters, chunkIds }) => {
     }
 
     const jobsWithFilteredData = jobs.map((job) => {
-      const { modules } = job?.metrics?.webpack || {};
+      const modules = job?.metrics?.webpack?.modules || {};
 
       const filteredModules = Object.entries(modules).reduce((agg, [moduleId, moduleEntry]) => {
         const match = intersection(moduleEntry.chunkIds, includedChunkIds);

--- a/packages/webpack-plugin/src/webpack-plugin.js
+++ b/packages/webpack-plugin/src/webpack-plugin.js
@@ -62,15 +62,18 @@ const generateReports = async (compilation, options) => {
 
   try {
     if (compare) {
-      baselineStats = await readBaseline();
-      baselineStats = filter(baselineStats);
+      const baselineStatsData = await readBaseline();
+      baselineStats = filter(baselineStatsData);
       if (!options.silent) logger.info(`Read baseline from ${baselineFilepath}`);
     }
   } catch (err) {
     logger.warn(TEXT.PLUGIN_BASELINE_MISSING_WARN);
   }
 
-  const jobs = createJobs([{ webpack: data }, ...(compare ? [{ webpack: baselineStats }] : [])]);
+  const jobs = createJobs([
+    { webpack: data },
+    ...(compare && baselineStats ? [{ webpack: baselineStats }] : []),
+  ]);
   const report = createReport(jobs);
   const artifacts = createArtifacts(jobs, report, { html, json });
 


### PR DESCRIPTION
- fix(ui): BundleModules -  prevent error when comparing with an empty job
- fix(webpack-plugin): Skip compare mode if baseline is missing
