### PR TITLE
fix empty modules

### DIFF
--- a/packages/ui/src/components/bundle-modules/bundle-modules.utils.js
+++ b/packages/ui/src/components/bundle-modules/bundle-modules.utils.js
@@ -87,7 +87,11 @@ export const useModuleFilterByChunk = ({ jobs, filters, chunkIds }) => {
     }
 
     const jobsWithFilteredData = jobs.map((job) => {
-      const modules = job?.metrics?.webpack?.modules || {};
+      const modules = job?.metrics?.webpack?.modules;
+
+      if (!modules) {
+        return job;
+      }
 
       const filteredModules = Object.entries(modules).reduce((agg, [moduleId, moduleEntry]) => {
         const match = intersection(moduleEntry.chunkIds, includedChunkIds);


### PR DESCRIPTION
- fix(ui): BundleModules -  prevent error when comparing with an empty job
- fix(webpack-plugin): Skip compare mode if baseline is missing
- fix(ui): BundleModules - skip filtering when job modules are empty
