### PR TITLE
Order By Delta: use literal byte delta

### DIFF
--- a/packages/ui/src/components/bundle-assets/bundle-assets.utils.js
+++ b/packages/ui/src/components/bundle-assets/bundle-assets.utils.js
@@ -77,7 +77,7 @@ export const getCustomSort = (sortId) => (item) => {
   }
 
   if (sortId === SORT_BY_DELTA) {
-    return item?.runs?.[0]?.deltaPercentage || 0;
+    return item?.runs?.[0]?.delta || 0;
   }
 
   if (sortId === SORT_BY_SIZE) {

--- a/packages/ui/src/components/bundle-modules/bundle-modules.utils.js
+++ b/packages/ui/src/components/bundle-modules/bundle-modules.utils.js
@@ -35,7 +35,7 @@ export const getCustomSort = (sortBy) => (item) => {
   }
 
   if (sortBy === SORT_BY_DELTA) {
-    return item?.runs?.[0]?.deltaPercentage || 0;
+    return item?.runs?.[0]?.delta || 0;
   }
 
   return [!item.changed, item.key];

--- a/packages/ui/src/components/bundle-packages/bundle-packages.utils.js
+++ b/packages/ui/src/components/bundle-packages/bundle-packages.utils.js
@@ -31,7 +31,7 @@ export const getCustomSort = (sortId) => (item) => {
   }
 
   if (sortId === SORT_BY_DELTA) {
-    return item?.runs?.[0]?.deltaPercentage || 0;
+    return item?.runs?.[0]?.delta || 0;
   }
 
   if (sortId === SORT_BY_SIZE) {


### PR DESCRIPTION
Instead of using %.

Sorting by % change isn't useful when files (packages / modules / assets) are all different sizes. Instead, let's sort by the actual delta in bytes.

Closes #2980