### PR TITLE
Update query string encoding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32961,7 +32961,6 @@
         "@bundle-stats/utils": "^4.8.0",
         "ariakit": "2.0.0-next.44",
         "modern-css-reset": "1.4.0",
-        "query-string": "7.1.3",
         "use-query-params": "2.2.1"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8533,6 +8533,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/history": {
+      "version": "4.7.11",
+      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.11.tgz",
+      "integrity": "sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==",
+      "dev": true
+    },
     "node_modules/@types/html-minifier-terser": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
@@ -8766,6 +8772,27 @@
         "@types/prop-types": "*",
         "@types/scheduler": "*",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-router": {
+      "version": "5.1.20",
+      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.20.tgz",
+      "integrity": "sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-router-dom": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.3.3.tgz",
+      "integrity": "sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==",
+      "dev": true,
+      "dependencies": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "@types/react-router": "*"
       }
     },
     "node_modules/@types/scheduler": {
@@ -32946,6 +32973,7 @@
         "@storybook/react": "7.5.3",
         "@storybook/react-webpack5": "7.5.3",
         "@types/react": "18.2.37",
+        "@types/react-router-dom": "5.3.3",
         "babel-plugin-require-context-hook": "1.0.0",
         "classnames": "2.3.2",
         "colormap": "2.3.2",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -44,6 +44,7 @@
     "@storybook/react": "7.5.3",
     "@storybook/react-webpack5": "7.5.3",
     "@types/react": "18.2.37",
+    "@types/react-router-dom": "5.3.3",
     "babel-plugin-require-context-hook": "1.0.0",
     "classnames": "2.3.2",
     "colormap": "2.3.2",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -76,7 +76,6 @@
     "@bundle-stats/utils": "^4.8.0",
     "ariakit": "2.0.0-next.44",
     "modern-css-reset": "1.4.0",
-    "query-string": "7.1.3",
     "use-query-params": "2.2.1"
   }
 }

--- a/packages/ui/src/app/app.jsx
+++ b/packages/ui/src/app/app.jsx
@@ -5,24 +5,24 @@ import { HashRouter, NavLink, Route, Switch, useLocation } from 'react-router-do
 import { COMPONENT } from '@bundle-stats/utils';
 
 import { URLS } from '../constants';
-import { Box } from '../layout/box';
-import { Container } from '../ui/container';
 import { BundleAssets } from '../components/bundle-assets';
 import { BundleAssetsTotalsChartBars } from '../components/bundle-assets-totals-chart-bars';
-import { Tabs } from '../ui/tabs';
-import { Footer } from '../layout/footer';
-import { Stack } from '../layout/stack';
 import { BundleAssetsTotalsTable } from '../components/bundle-assets-totals-table';
 import { BundleModules } from '../components/bundle-modules';
 import { BundlePackages } from '../components/bundle-packages';
 import { Insights } from '../components/insights';
+import { MetricsTableTitle } from '../components';
 import { Summary } from '../components/summary';
 import { TotalSizeTypeTitle } from '../components/total-size-type-title';
+import { Box } from '../layout/box';
+import { Footer } from '../layout/footer';
+import { Stack } from '../layout/stack';
+import { Container } from '../ui/container';
+import { Tabs } from '../ui/tabs';
 import { QueryStateProvider, useComponentQueryState } from '../query-state';
 import I18N from '../i18n';
 import { Header } from './header';
 import css from './app.module.css';
-import { MetricsTableTitle } from '../components';
 
 const ScrollToTop = () => {
   const { pathname } = useLocation();
@@ -69,11 +69,13 @@ const OverviewContent = () => {
     const webpackInsights = jobs?.[0]?.insights?.webpack;
 
     if (!webpackInsights) {
-      return null
+      return null;
     }
 
     const res = {
-      ...(webpackInsights.duplicatePackagesV3 && { duplicatePackages: webpackInsights.duplicatePackagesV3 }),
+      ...(webpackInsights.duplicatePackagesV3 && {
+        duplicatePackages: webpackInsights.duplicatePackagesV3,
+      }),
       ...(webpackInsights.newPackages && { newPackages: webpackInsights.newPackages }),
     };
 
@@ -83,7 +85,6 @@ const OverviewContent = () => {
 
     return res;
   }, [jobs]);
-
 
   return (
     <Stack space="medium">
@@ -114,9 +115,9 @@ const AssetsContent = () => {
 
   return (
     <Container>
-        <Box outline>
-          <BundleAssets jobs={jobs} setState={bundleStatsSetState} {...bundleStatsState} />
-        </Box>
+      <Box outline>
+        <BundleAssets jobs={jobs} setState={bundleStatsSetState} {...bundleStatsState} />
+      </Box>
     </Container>
   );
 };
@@ -129,9 +130,9 @@ const ModulesContent = () => {
 
   return (
     <Container>
-        <Box outline>
-          <BundleModules jobs={jobs} setState={bundleModulesSetState} {...bundleModulesState} />
-        </Box>
+      <Box outline>
+        <BundleModules jobs={jobs} setState={bundleModulesSetState} {...bundleModulesState} />
+      </Box>
     </Container>
   );
 };
@@ -144,9 +145,9 @@ const PackagesContent = () => {
 
   return (
     <Container>
-        <Box outline>
-          <BundlePackages jobs={jobs} {...bundlePackagesState} setState={bundlePackagesSetState} />
-        </Box>
+      <Box outline>
+        <BundlePackages jobs={jobs} {...bundlePackagesState} setState={bundlePackagesSetState} />
+      </Box>
     </Container>
   );
 };

--- a/packages/ui/src/query-state.jsx
+++ b/packages/ui/src/query-state.jsx
@@ -1,9 +1,9 @@
 import React, { useCallback } from 'react';
-import { JsonParam, QueryParamProvider, useQueryParams } from 'use-query-params';
-import { ReactRouter5Adapter } from 'use-query-params/adapters/react-router-5'
-import { parse, stringify } from 'query-string'
 import isEqual from 'lodash/isEqual';
 import merge from 'lodash/merge';
+import { JsonParam, QueryParamProvider, useQueryParams } from 'use-query-params';
+import { ReactRouter5Adapter } from 'use-query-params/adapters/react-router-5';
+import { parse, stringify } from 'query-string';
 
 export const QueryStateProvider = (props) => (
   <QueryParamProvider

--- a/packages/ui/src/query-state.tsx
+++ b/packages/ui/src/query-state.tsx
@@ -5,7 +5,11 @@ import { JsonParam, QueryParamProvider, useQueryParams } from 'use-query-params'
 import { ReactRouter5Adapter } from 'use-query-params/adapters/react-router-5';
 import { parse, stringify } from 'query-string';
 
-export const QueryStateProvider = (props) => (
+interface QueryStateProviderProps {
+  children: React.ReactNode;
+}
+
+export const QueryStateProvider = (props: QueryStateProviderProps) => (
   <QueryParamProvider
     adapter={ReactRouter5Adapter}
     options={{
@@ -16,7 +20,7 @@ export const QueryStateProvider = (props) => (
   />
 );
 
-export const useComponentQueryState = (componentName) => {
+export const useComponentQueryState = (componentName: string) => {
   const [search, setSearch] = useQueryParams({
     [componentName]: JsonParam,
   });
@@ -24,7 +28,7 @@ export const useComponentQueryState = (componentName) => {
   const state = search[componentName];
 
   const setState = useCallback(
-    (newState) => {
+    (newState: Record<string, unknown>) => {
       const newComponentState = merge({}, state, newState);
 
       // Deep check to prevent unnecessary state changes

--- a/packages/ui/src/query-state.tsx
+++ b/packages/ui/src/query-state.tsx
@@ -2,7 +2,6 @@ import React, { useCallback } from 'react';
 import isEqual from 'lodash/isEqual';
 import { QueryParamProvider, useQueryParams } from 'use-query-params';
 import { ReactRouter5Adapter } from 'use-query-params/adapters/react-router-5';
-import { parse, stringify } from 'query-string';
 import { COMPONENT_STATE_META } from '@bundle-stats/utils';
 
 interface QueryStateProviderProps {
@@ -10,14 +9,7 @@ interface QueryStateProviderProps {
 }
 
 export const QueryStateProvider = (props: QueryStateProviderProps) => (
-  <QueryParamProvider
-    adapter={ReactRouter5Adapter}
-    options={{
-      searchStringToObject: parse,
-      objectToSearchString: stringify,
-    }}
-    {...props}
-  />
+  <QueryParamProvider adapter={ReactRouter5Adapter} {...props} />
 );
 
 export const useComponentQueryState = (componentName: string) => {

--- a/packages/ui/src/query-state.tsx
+++ b/packages/ui/src/query-state.tsx
@@ -1,9 +1,9 @@
 import React, { useCallback } from 'react';
 import isEqual from 'lodash/isEqual';
-import merge from 'lodash/merge';
-import { JsonParam, QueryParamProvider, useQueryParams } from 'use-query-params';
+import { QueryParamProvider, useQueryParams } from 'use-query-params';
 import { ReactRouter5Adapter } from 'use-query-params/adapters/react-router-5';
 import { parse, stringify } from 'query-string';
+import { COMPONENT_STATE_META } from '@bundle-stats/utils';
 
 interface QueryStateProviderProps {
   children: React.ReactNode;
@@ -21,25 +21,23 @@ export const QueryStateProvider = (props: QueryStateProviderProps) => (
 );
 
 export const useComponentQueryState = (componentName: string) => {
-  const [search, setSearch] = useQueryParams({
-    [componentName]: JsonParam,
+  const [queryState, setQueryState] = useQueryParams({
+    [componentName]: COMPONENT_STATE_META[componentName],
   });
 
-  const state = search[componentName];
+  const componentState = queryState[componentName];
 
   const setState = useCallback(
     (newState: Record<string, unknown>) => {
-      const newComponentState = merge({}, state, newState);
-
       // Deep check to prevent unnecessary state changes
-      if (isEqual(newComponentState, state)) {
+      if (isEqual(componentState, newState)) {
         return;
       }
 
-      setSearch({ [componentName]: newComponentState });
+      setQueryState({ [componentName]: newState });
     },
-    [state],
+    [componentState],
   );
 
-  return [state, setState];
+  return [componentState, setState];
 };

--- a/packages/utils/src/utils/__tests__/component-links.ts
+++ b/packages/utils/src/utils/__tests__/component-links.ts
@@ -1,19 +1,38 @@
-import { decodeComponentStateQueryString, getComponentStateQueryString } from '../component-links';
+import { getComponentStateData, getComponentStateQueryString } from '../component-links';
 
 describe('component links', () => {
-  describe('decodeComponentStateQueryString', () => {
+  describe('getComponentState', () => {
     test('should return empty component state when query string does not contain any state', () => {
-      expect(decodeComponentStateQueryString('')).toEqual({});
-      expect(decodeComponentStateQueryString('a=1')).toEqual({ a: '1' });
+      expect(getComponentStateData('')).toEqual({});
+      expect(getComponentStateData('a=1')).toEqual({ a: '1' });
     });
-    test('should decode component state from query string', () => {
+    test('should decode component state from json ecoded query string (obsolete)', () => {
       expect(
-        decodeComponentStateQueryString(
+        getComponentStateData(
           'ba=%7B%22search%22%3A%22%22%2C%22filters%22%3A%7B%22changed%22%3Atrue%7D%7D&bm=%7B%22search%22%3A%22query%22%2C%22filters%22%3A%7B%22changed%22%3Afalse%7D%7D',
         ),
       ).toEqual({
         ba: {
-          search: '',
+          filters: {
+            changed: true,
+          },
+        },
+        bm: {
+          search: 'query',
+          filters: {
+            changed: false,
+          },
+        },
+      });
+    });
+
+    test('should decode component state from mixed encoder query string', () => {
+      expect(
+        getComponentStateData(
+          'ba=%7B%22search%22%3A%22%22%2C%22filters%22%3A%22changed-1%22%7D&bm=%7B%22search%22%3A%22query%22%2C%22filters%22%3A%22changed-0%22%7D',
+        ),
+      ).toEqual({
+        ba: {
           filters: {
             changed: true,
           },
@@ -27,6 +46,7 @@ describe('component links', () => {
       });
     });
   });
+
   describe('getComponentStateQueryString', () => {
     test('should return empty string when params are missing', () => {
       expect(getComponentStateQueryString()).toEqual('');
@@ -58,7 +78,7 @@ describe('component links', () => {
           },
         }),
       ).toEqual(
-        'ba=%7B%22search%22%3A%22%22%2C%22filters%22%3A%7B%22changed%22%3Atrue%7D%7D&bm=%7B%22search%22%3A%22query%22%2C%22filters%22%3A%7B%22changed%22%3Afalse%2C%22c.100%22%3Afalse%2C%22c.200%22%3Afalse%2C%22c.300%22%3Afalse%2C%22c.400%22%3Afalse%2C%22c.500%22%3Afalse%2C%22c.600%22%3Afalse%2C%22c.700%22%3Afalse%2C%22c.800%22%3Afalse%2C%22c.900%22%3Afalse%7D%7D',
+        'ba=%7B%22filters%22%3A%22changed-1%22%7D&bm=%7B%22search%22%3A%22query%22%2C%22filters%22%3A%22changed-0_c.100-0_c.200-0_c.300-0_c.400-0_c.500-0_c.600-0_c.700-0_c.800-0_c.900-0%22%7D',
       );
     });
   });

--- a/packages/utils/src/utils/__tests__/component-links.ts
+++ b/packages/utils/src/utils/__tests__/component-links.ts
@@ -45,11 +45,20 @@ describe('component links', () => {
             search: 'query',
             filters: {
               changed: false,
+              'c.100': false,
+              'c.200': false,
+              'c.300': false,
+              'c.400': false,
+              'c.500': false,
+              'c.600': false,
+              'c.700': false,
+              'c.800': false,
+              'c.900': false,
             },
           },
         }),
       ).toEqual(
-        'ba=%7B%22search%22%3A%22%22%2C%22filters%22%3A%7B%22changed%22%3Atrue%7D%7D&bm=%7B%22search%22%3A%22query%22%2C%22filters%22%3A%7B%22changed%22%3Afalse%7D%7D',
+        'ba=%7B%22search%22%3A%22%22%2C%22filters%22%3A%7B%22changed%22%3Atrue%7D%7D&bm=%7B%22search%22%3A%22query%22%2C%22filters%22%3A%7B%22changed%22%3Afalse%2C%22c.100%22%3Afalse%2C%22c.200%22%3Afalse%2C%22c.300%22%3Afalse%2C%22c.400%22%3Afalse%2C%22c.500%22%3Afalse%2C%22c.600%22%3Afalse%2C%22c.700%22%3Afalse%2C%22c.800%22%3Afalse%2C%22c.900%22%3Afalse%7D%7D',
       );
     });
   });

--- a/packages/utils/src/utils/__tests__/component-links.ts
+++ b/packages/utils/src/utils/__tests__/component-links.ts
@@ -1,6 +1,32 @@
-import { getComponentStateQueryString } from '../component-links';
+import { decodeComponentStateQueryString, getComponentStateQueryString } from '../component-links';
 
 describe('component links', () => {
+  describe('decodeComponentStateQueryString', () => {
+    test('should return empty component state when query string does not contain any state', () => {
+      expect(decodeComponentStateQueryString('')).toEqual({});
+      expect(decodeComponentStateQueryString('a=1')).toEqual({ a: '1' });
+    });
+    test('should decode component state from query string', () => {
+      expect(
+        decodeComponentStateQueryString(
+          'ba=%7B%22search%22%3A%22%22%2C%22filters%22%3A%7B%22changed%22%3Atrue%7D%7D&bm=%7B%22search%22%3A%22query%22%2C%22filters%22%3A%7B%22changed%22%3Afalse%7D%7D',
+        ),
+      ).toEqual({
+        ba: {
+          search: '',
+          filters: {
+            changed: true,
+          },
+        },
+        bm: {
+          search: 'query',
+          filters: {
+            changed: false,
+          },
+        },
+      });
+    });
+  });
   describe('getComponentStateQueryString', () => {
     test('should return empty string when params are missing', () => {
       expect(getComponentStateQueryString()).toEqual('');
@@ -9,6 +35,12 @@ describe('component links', () => {
     test('should encode params', () => {
       expect(
         getComponentStateQueryString({
+          ba: {
+            search: '',
+            filters: {
+              changed: true,
+            },
+          },
           bm: {
             search: 'query',
             filters: {
@@ -17,7 +49,7 @@ describe('component links', () => {
           },
         }),
       ).toEqual(
-        'bm=%7B%22search%22%3A%22query%22%2C%22filters%22%3A%7B%22changed%22%3Afalse%7D%7D',
+        'ba=%7B%22search%22%3A%22%22%2C%22filters%22%3A%7B%22changed%22%3Atrue%7D%7D&bm=%7B%22search%22%3A%22query%22%2C%22filters%22%3A%7B%22changed%22%3Afalse%7D%7D',
       );
     });
   });

--- a/packages/utils/src/utils/__tests__/component-links.ts
+++ b/packages/utils/src/utils/__tests__/component-links.ts
@@ -1,0 +1,24 @@
+import { getComponentStateQueryString } from '../component-links';
+
+describe('component links', () => {
+  describe('getComponentStateQueryString', () => {
+    test('should return empty string when params are missing', () => {
+      expect(getComponentStateQueryString()).toEqual('');
+    });
+
+    test('should encode params', () => {
+      expect(
+        getComponentStateQueryString({
+          bm: {
+            search: 'query',
+            filters: {
+              changed: false,
+            },
+          },
+        }),
+      ).toEqual(
+        'bm=%7B%22search%22%3A%22query%22%2C%22filters%22%3A%7B%22changed%22%3Afalse%7D%7D',
+      );
+    });
+  });
+});

--- a/packages/utils/src/utils/component-links.ts
+++ b/packages/utils/src/utils/component-links.ts
@@ -1,5 +1,5 @@
-import { stringify } from 'query-string';
-import { JsonParam, encodeQueryParams } from 'serialize-query-params';
+import { parse, stringify } from 'query-string';
+import { JsonParam, decodeQueryParams, encodeQueryParams } from 'serialize-query-params';
 
 import {
   FILE_TYPES,
@@ -363,17 +363,19 @@ export const getBundlePackagesByNameComponentLink = (search: string): ComponentL
 
 type ComponentStateQueryStringParams = Record<string, ComponentLinkParams>;
 
-export const getComponentStateQueryString = (params: ComponentStateQueryStringParams = {}) => {
-  const meta = Object.keys(params).reduce(
-    (agg, componentName) => ({
-      ...agg,
-      [componentName]: JsonParam,
-    }),
-    {},
-  );
+export const COMPONENT_STATE_META = {
+  [COMPONENT.BUNDLE_ASSETS]: JsonParam,
+  [COMPONENT.BUNDLE_MODULES]: JsonParam,
+  [COMPONENT.BUNDLE_PACKAGES]: JsonParam,
+} as const;
 
-  return stringify(encodeQueryParams(meta, params));
+export const getComponentStateQueryString = (params: ComponentStateQueryStringParams = {}) => {
+  return stringify(encodeQueryParams(COMPONENT_STATE_META, params));
 };
+
+export const decodeComponentStateQueryString = (
+  queryString: string,
+): ComponentStateQueryStringParams => decodeQueryParams(COMPONENT_STATE_META, parse(queryString));
 
 export const METRIC_COMPONENT_LINKS = new Map([
   ['webpack.totalSizeByTypeALL', { link: TOTALS }],

--- a/packages/utils/src/utils/component-links.ts
+++ b/packages/utils/src/utils/component-links.ts
@@ -391,21 +391,27 @@ export const ComponentStateParam: QueryParamConfig<any, any> = {
     const search = StringParam.encode(sectionState.search);
     const entryId = StringParam.encode(sectionState.entryId);
 
-    const filters = ObjectParam.encode(
-      Object.entries(sectionState.filters || {}).reduce(
-        (agg, [key, val]) => ({
-          ...agg,
-          [key]: BooleanParam.encode(val as boolean),
-        }),
-        {},
-      ),
-    );
-
-    return JsonParam.encode({
-      ...(search && { search }),
-      ...(entryId && { entryId }),
-      ...(!isEmpty(filters) && { filters }),
+    const filtersEncodedValues: Record<string, string> = {};
+    Object.entries(sectionState.filters || {}).forEach(([key, val]) => {
+      filtersEncodedValues[key] = BooleanParam.encode(!!val) as string;
     });
+    const filters = ObjectParam.encode(filtersEncodedValues);
+
+    const data = {} as any;
+
+    if (search) {
+      data.search = search;
+    }
+
+    if (entryId) {
+      data.entryId = entryId;
+    }
+
+    if (!isEmpty(filters)) {
+      data.filters = filters;
+    }
+
+    return JsonParam.encode(data);
   },
   decode: (queryString) => {
     const params = JsonParam.decode(queryString);
@@ -438,11 +444,19 @@ export const ComponentStateParam: QueryParamConfig<any, any> = {
     }
 
     // Include only the truthy values
-    const result = {
-      ...(search && { search }),
-      ...(entryId && { entryId }),
-      ...(!isEmpty(filters) && { filters }),
-    };
+    const result: Record<string, any> = {};
+
+    if (search) {
+      result.search = search;
+    }
+
+    if (entryId) {
+      result.entryId = entryId;
+    }
+
+    if (!isEmpty(filters)) {
+      result.filters = filters;
+    }
 
     if (isEmpty(result)) {
       return undefined;

--- a/packages/utils/src/utils/component-links.ts
+++ b/packages/utils/src/utils/component-links.ts
@@ -27,7 +27,7 @@ export type ComponentLinkFilters = Record<string, boolean>;
 export interface ComponentLinkParams {
   search?: string;
   entryId?: string;
-  filters: ComponentLinkFilters;
+  filters?: ComponentLinkFilters;
 }
 
 export interface ComponentLink {
@@ -361,7 +361,9 @@ export const getBundlePackagesByNameComponentLink = (search: string): ComponentL
   },
 });
 
-export const getComponentStateQueryString = (params = {}) => {
+type ComponentStateQueryStringParams = Record<string, ComponentLinkParams>;
+
+export const getComponentStateQueryString = (params: ComponentStateQueryStringParams = {}) => {
   const meta = Object.keys(params).reduce(
     (agg, componentName) => ({
       ...agg,


### PR DESCRIPTION
Mixed strategy to encode the component state into the URL with a smaller size 

| | Before | After |
|---|---|---|
| ~600 chunks | `16k` | `6K` |

rel: https://github.com/relative-ci/bundle-stats/issues/3946