### PR TITLE
module-info: fix reversed job names!

### DIFF
--- a/packages/ui/src/components/module-info/module-info.tsx
+++ b/packages/ui/src/components/module-info/module-info.tsx
@@ -76,7 +76,7 @@ export const ModuleInfo = (props: ModuleInfoProps & React.ComponentProps<'div'>)
           (currentRun, index) =>
             !isEmpty(currentRun?.chunkIds) && (
               <EntryInfo.Meta label="Chunks" className={css.chunks}>
-                Job #{index + 1}:
+                {labels[index]}:
                 {currentRun.chunkIds.map((chunkId) => {
                   const chunk = chunks?.find(({ id }) => id === chunkId);
 


### PR DESCRIPTION
The index in the array of jobs isn't the number!

Before this change the `Job #1` and `Job #2` were reversed.

Turns out, everywhere else we reference the jobs we always look up the label in the labels map. That wasn't being done here and thus the jobs were actually mis-labeled (2 was 1 and 1 was 2) making the chunk list in module-info attributed to the wrong job.

Now it's fixed and the right job labels are show.

Here's an example of the bug (notice the different ordering in the jobs):
![image](https://github.com/relative-ci/bundle-stats/assets/26855/1088f418-f79d-465e-a4a5-d022d0763a4e)
