### PR TITLE
fix(ui): BundleAssets/Modules/Packages - do not clear sort params when openning entry side info

### DIFF
--- a/packages/ui/src/components/asset-name/asset-name.tsx
+++ b/packages/ui/src/components/asset-name/asset-name.tsx
@@ -16,11 +16,11 @@ const RUNS_LABELS = [RUN_TITLE_CURRENT, RUN_TITLE_BASELINE];
 export type AssetNameProps = {
   className?: string;
   row: ReportMetricAssetRow;
-  customComponentLink: ElementType;
+  EntryComponentLink: ElementType;
 };
 
 export const AssetName = (props: AssetNameProps) => {
-  const { className = '', customComponentLink: CustomComponentLink, row } = props;
+  const { className = '', EntryComponentLink, row } = props;
   const { label, isNotPredictive, runs, isChunk, isEntry, isInitial } = row;
 
   return (
@@ -35,7 +35,7 @@ export const AssetName = (props: AssetNameProps) => {
         </HoverCard>
       )}
 
-      <CustomComponentLink entryId={row.key} className={css.name}>
+      <EntryComponentLink entryId={row.key} className={css.name}>
         <span className={css.metaTags}>
           {isEntry && (
             <AssetMetaTag className={css.metaTag} title="Entrypoint" tag="entry" status={isEntry} />
@@ -53,7 +53,7 @@ export const AssetName = (props: AssetNameProps) => {
           )}
         </span>
         <FileName className={css.nameText} name={label} />
-      </CustomComponentLink>
+      </EntryComponentLink>
     </span>
   );
 };

--- a/packages/ui/src/components/bundle-assets/bundle-assets.jsx
+++ b/packages/ui/src/components/bundle-assets/bundle-assets.jsx
@@ -204,26 +204,30 @@ export const BundleAssets = (props) => {
     [items, totalRowCount],
   );
 
-  const assetNameCustomComponentLink = useCallback(
+  const EntryComponentLink = useCallback(
     ({ entryId: assetEntryId, ...assetNameRestProps }) => (
       <CustomComponentLink
         section={SECTIONS.ASSETS}
-        params={{ [COMPONENT.BUNDLE_ASSETS]: { filters, search, entryId: assetEntryId } }}
+        params={{
+          [COMPONENT.BUNDLE_ASSETS]: {
+            filters,
+            search,
+            entryId: assetEntryId,
+            sortBy: sort.field,
+            direction: sort.direction,
+          },
+        }}
         {...assetNameRestProps}
       />
     ),
-    [CustomComponentLink, filters, search],
+    [CustomComponentLink, filters, search, sort],
   );
 
   const renderRowHeader = useCallback(
     (row) => (
-      <AssetName
-        row={row}
-        customComponentLink={assetNameCustomComponentLink}
-        className={css.assetName}
-      />
+      <AssetName row={row} EntryComponentLink={EntryComponentLink} className={css.assetName} />
     ),
-    [CustomComponentLink, filters, search],
+    [EntryComponentLink],
   );
 
   const emptyMessage = useMemo(
@@ -386,7 +390,7 @@ BundleAssets.propTypes = {
   search: PropTypes.string.isRequired,
   updateSearch: PropTypes.func.isRequired,
   sort: PropTypes.shape({
-    sortBy: PropTypes.string,
+    field: PropTypes.string,
     direction: PropTypes.string,
   }).isRequired,
   updateSort: PropTypes.func.isRequired,

--- a/packages/ui/src/components/bundle-modules/bundle-modules.tsx
+++ b/packages/ui/src/components/bundle-modules/bundle-modules.tsx
@@ -1,3 +1,4 @@
+import type { ComponentProps, ElementType } from 'react';
 import React, { useCallback, useMemo, useState } from 'react';
 import cx from 'classnames';
 import { SECTIONS, COMPONENT, type Job, ReportMetricRow } from '@bundle-stats/utils';
@@ -42,35 +43,21 @@ const DISPLAY_TYPE_GROUPS = {
 
 interface RowHeaderProps {
   row: ReportMetricRow;
-  filters?: any;
-  search?: string;
-  moduleMetric?: string;
-  customComponentLink: React.ElementType;
+  EntryComponentLink: ElementType;
 }
 
 const RowHeader = (props: RowHeaderProps) => {
-  const { row, filters, search, moduleMetric, customComponentLink: CustomComponentLink } = props;
+  const { row, EntryComponentLink } = props;
 
   const moduleRow = row as ReportMetricModuleRow;
 
   return (
-    <CustomComponentLink
-      section={SECTIONS.MODULES}
-      params={{
-        [COMPONENT.BUNDLE_MODULES]: {
-          filters,
-          search,
-          entryId: moduleRow.key,
-          metric: moduleMetric,
-        },
-      }}
-      className={css.name}
-    >
+    <EntryComponentLink entryId={row.key} className={css.name}>
       {moduleRow.duplicated && (
         <Tag className={css.nameTagDuplicated} size="small" kind={Tag.KINDS.DANGER} />
       )}
       <FileName className={css.nameText} name={moduleRow.label} />
-    </CustomComponentLink>
+    </EntryComponentLink>
   );
 };
 
@@ -209,6 +196,28 @@ export const BundleModules = (props: BundleModulesProps) => {
     [jobs, filters, chunks],
   );
 
+  const EntryComponentLink = useCallback(
+    ({
+      entryId: moduleEntryId,
+      ...moduleNameRestProps
+    }: { entryId: string } & ComponentProps<typeof CustomComponentLink>) => (
+      <CustomComponentLink
+        section={SECTIONS.MODULES}
+        params={{
+          [COMPONENT.BUNDLE_MODULES]: {
+            filters,
+            search,
+            entryId: moduleEntryId,
+            sortBy: sort.field,
+            direction: sort.direction,
+          },
+        }}
+        {...moduleNameRestProps}
+      />
+    ),
+    [CustomComponentLink, filters, search, sort],
+  );
+
   const metricsTableTitle = useMemo(
     () => (
       <MetricsTableTitle
@@ -222,16 +231,8 @@ export const BundleModules = (props: BundleModulesProps) => {
   );
 
   const renderRowHeader = useCallback(
-    (row: ReportMetricRow) => (
-      <RowHeader
-        row={row}
-        filters={filters}
-        search={search}
-        moduleMetric={moduleMetric}
-        customComponentLink={CustomComponentLink}
-      />
-    ),
-    [jobs, chunks, CustomComponentLink, filters, search, moduleMetric],
+    (row: ReportMetricRow) => <RowHeader row={row} EntryComponentLink={EntryComponentLink} />,
+    [EntryComponentLink],
   );
 
   const emptyMessage = useMemo(


### PR DESCRIPTION


- rel: https://github.com/relative-ci/bundle-stats/pull/4824

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced `EntryComponentLink` to replace `CustomComponentLink`, simplifying component structures across multiple components.
	- Enhanced link functionality with sorting capabilities in `BundleAssets`.

- **Bug Fixes**
	- Streamlined prop structures in `RowHeader`, `PackageName`, and `BundleModules` components for improved clarity and maintainability.

- **Documentation**
	- Updated prop types and method signatures to reflect new naming conventions and simplified structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->