### PR TITLE
Error with v418 vite maximum call stack size exceeded rltv 1169

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24098,10 +24098,9 @@
       }
     },
     "node_modules/rollup-plugin-webpack-stats": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-webpack-stats/-/rollup-plugin-webpack-stats-2.0.0.tgz",
-      "integrity": "sha512-PgZvQmVH0FoeH3q9EomjSBLZhCtJNrt+yqciVdgAmKP51EPXmrjaGUb6Hi/vccv5O/SMBKENJQ3pw54vp1puBw==",
-      "license": "MIT",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-webpack-stats/-/rollup-plugin-webpack-stats-2.0.1.tgz",
+      "integrity": "sha512-1JALgjz4RDe14SowXJxAsQqJxGnj6JF4TIRo0FistxspFr3TyYIWCpO8B5qaes7vfdKxSNTowJtuQTOlZOobMA==",
       "dependencies": {
         "rollup-plugin-stats": "1.3.2"
       },
@@ -28171,7 +28170,7 @@
       "license": "MIT",
       "dependencies": {
         "@bundle-stats/cli-utils": "^4.18.0",
-        "rollup-plugin-webpack-stats": "2.0.0"
+        "rollup-plugin-webpack-stats": "2.0.1"
       },
       "devDependencies": {
         "@tsconfig/node16": "16.1.3",

--- a/packages/rollup-plugin/package.json
+++ b/packages/rollup-plugin/package.json
@@ -46,7 +46,7 @@
   "homepage": "https://github.com/relative-ci/bundle-stats/blob/master/packages/rollup-plugin#readme",
   "dependencies": {
     "@bundle-stats/cli-utils": "^4.18.0",
-    "rollup-plugin-webpack-stats": "2.0.0"
+    "rollup-plugin-webpack-stats": "2.0.1"
   },
   "devDependencies": {
     "@tsconfig/node16": "16.1.3",


### PR DESCRIPTION
- resolves: https://github.com/relative-ci/bundle-stats/issues/4950

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated dependency `rollup-plugin-webpack-stats` to version 2.0.1
<!-- end of auto-generated comment: release notes by coderabbit.ai -->