### PR TITLE
Prevent resetting metrics display group type

### DIFF
--- a/packages/ui/src/components/bundle-assets/bundle-assets.tsx
+++ b/packages/ui/src/components/bundle-assets/bundle-assets.tsx
@@ -8,7 +8,7 @@ import { COMPONENT, SECTIONS } from '@bundle-stats/utils';
 import type { ReportMetricAssetRow, SortAction } from '../../types';
 import config from '../../config.json';
 import I18N from '../../i18n';
-import { MetricsDisplayType } from '../../constants';
+import { MetricsDisplayGroupBy, MetricsDisplayType } from '../../constants';
 import { useMetricsDisplayType } from '../../hooks/metrics-display-type';
 import { Box } from '../../layout/box';
 import { FlexStack } from '../../layout/flex-stack';
@@ -34,7 +34,7 @@ import { getFilters } from './bundle-assets.utils';
 import css from './bundle-assets.module.css';
 
 const DISPLAY_TYPE_GROUPS = {
-  [MetricsDisplayType.TREEMAP]: ['folder'],
+  [MetricsDisplayType.TREEMAP]: [MetricsDisplayGroupBy.FOLDER],
 };
 
 interface ViewMetricsTreemapProps {

--- a/packages/ui/src/components/bundle-modules/bundle-modules.tsx
+++ b/packages/ui/src/components/bundle-modules/bundle-modules.tsx
@@ -8,7 +8,12 @@ import { WebpackChunk } from '@bundle-stats/utils';
 import type { ReportMetricModuleRow, SortAction } from '../../types';
 import config from '../../config.json';
 import I18N from '../../i18n';
-import { MetricsDisplayType, ModuleSizeMetric, ModuleSizeMetrics } from '../../constants';
+import {
+  MetricsDisplayGroupBy,
+  MetricsDisplayType,
+  ModuleSizeMetric,
+  ModuleSizeMetrics,
+} from '../../constants';
 import { Box } from '../../layout/box';
 import { FlexStack } from '../../layout/flex-stack';
 import { Stack } from '../../layout/stack';
@@ -38,7 +43,7 @@ import css from './bundle-modules.module.css';
 import { useMetricsDisplayType } from '../../hooks/metrics-display-type';
 
 const DISPLAY_TYPE_GROUPS = {
-  [MetricsDisplayType.TREEMAP]: ['folder'],
+  [MetricsDisplayType.TREEMAP]: [MetricsDisplayGroupBy.FOLDER],
 };
 
 interface RowHeaderProps {

--- a/packages/ui/src/components/bundle-packages/bundle-packages.jsx
+++ b/packages/ui/src/components/bundle-packages/bundle-packages.jsx
@@ -26,12 +26,12 @@ import { PackageInfo } from '../package-info';
 import { SEARCH_PLACEHOLDER } from './bundle-packages.i18n';
 import css from './bundle-packages.module.css';
 import { MetricsDisplaySelector } from '../metrics-display-selector';
-import { MetricsDisplayType } from '../../constants';
+import { MetricsDisplayGroupBy, MetricsDisplayType } from '../../constants';
 import { MetricsTreemap, getTreemapNodes, getTreemapNodesGroupedByPath } from '../metrics-treemap';
 import { useMetricsDisplayType } from '../../hooks/metrics-display-type';
 
 const DISPLAY_TYPE_GROUPS = {
-  [MetricsDisplayType.TREEMAP]: ['folder'],
+  [MetricsDisplayType.TREEMAP]: [MetricsDisplayGroupBy.FOLDER],
 };
 
 const getDropdownFilters = ({ compareMode, filters }) => ({

--- a/packages/ui/src/components/metrics-display-selector/metrics-display-selector.module.css
+++ b/packages/ui/src/components/metrics-display-selector/metrics-display-selector.module.css
@@ -1,4 +1,30 @@
-.buttonActive {
+.dropdownGroup {
+  border: 1px solid var(--color-outline);
+}
+
+.dropdownGroupButton {
+  padding: calc(var(--space-xxsmall) - 1px);
+}
+
+.dropdownGroupAnchor {
+  border: none;
+  border-left: 1px solid var(--color-outline);
+  border-radius: 0;
+}
+
+.dropdownGroupAnchor:hover,
+.dropdownGroupAnchor:focus,
+.dropdownGroupAnchor:active {
+  border-color: var(--color-outline);
+  box-shadow: none;
+  background: none;
+}
+
+.dropdownGroup:hover {
+  border-color: var(--color-outline-dark);
+}
+
+.itemActive {
   background: var(--color-highlight);
 }
 

--- a/packages/ui/src/components/metrics-display-selector/metrics-display-selector.tsx
+++ b/packages/ui/src/components/metrics-display-selector/metrics-display-selector.tsx
@@ -62,7 +62,7 @@ export const MetricsDisplaySelector = (
               type="button"
               glyph={displayProps.glyph}
               onClick={() => onSelect(displayType)}
-              className={isLast && css.itemLast}
+              className={cx(isLast && css.itemLast)}
               key={displayType}
             >
               {displayProps.label}
@@ -82,30 +82,46 @@ export const MetricsDisplaySelector = (
         ];
 
         return (
-          <Dropdown
-            glyph={displayProps.glyph}
-            label={displayProps.label}
-            className={cx(isLast && css.itemLast, isActive && css.buttonActive)}
+          <FlexStack
+            className={cx(css.dropdownGroup, isLast && css.itemLast, isActive && css.itemActive)}
             key={displayType}
           >
-            {displayGroupsData.map((displayGroupData) => {
-              const isGroupActive = isActive && displayGroupData.value === groupBy;
+            <Button
+              size="small"
+              glyph={displayProps.glyph}
+              onClick={() => onSelect(displayType)}
+              className={css.dropdownGroupButton}
+            >
+              {displayProps.label}
+            </Button>
+            <Dropdown
+              glyph={Icon.ICONS.CHEVRON_DOWN}
+              placement="bottom-end"
+              className={css.dropdownGroupAnchor}
+            >
+              {displayGroupsData.map((displayGroupData) => {
+                const isGroupActive = isActive && displayGroupData.value === groupBy;
 
-              return (
-                <DropdownItem
-                  onClick={() => onSelect(displayType, displayGroupData.value)}
-                  isActive={isGroupActive}
-                  className={cx(css.dropdownItem, isGroupActive && css.dropdownItemActive)}
-                  key={displayGroupData.value}
-                >
-                  <FlexStack space="xxxsmall" alignItems="center">
-                    <Icon glyph={Icon.ICONS.CHECK} size="small" className={css.dropdownItemIcon} />
-                    <span>{displayGroupData.label}</span>
-                  </FlexStack>
-                </DropdownItem>
-              );
-            })}
-          </Dropdown>
+                return (
+                  <DropdownItem
+                    onClick={() => onSelect(displayType, displayGroupData.value)}
+                    isActive={isGroupActive}
+                    className={cx(css.dropdownItem, isGroupActive && css.dropdownItemActive)}
+                    key={displayGroupData.value}
+                  >
+                    <FlexStack space="xxxsmall" alignItems="center">
+                      <Icon
+                        glyph={Icon.ICONS.CHECK}
+                        size="small"
+                        className={css.dropdownItemIcon}
+                      />
+                      <span>{displayGroupData.label}</span>
+                    </FlexStack>
+                  </DropdownItem>
+                );
+              })}
+            </Dropdown>
+          </FlexStack>
         );
       })}
     </ControlGroup>

--- a/packages/ui/src/components/metrics-display-selector/metrics-display-selector.tsx
+++ b/packages/ui/src/components/metrics-display-selector/metrics-display-selector.tsx
@@ -1,15 +1,17 @@
 import React from 'react';
 import cx from 'classnames';
 
-import { MetricsDisplayType } from '../../constants';
+import {
+  MetricsDisplayType,
+  MetricsDisplayGroupByDefault,
+  MetricsDisplayGroupBy,
+} from '../../constants';
 import { Button } from '../../ui/button';
 import { ControlGroup } from '../../ui/control-group';
 import { Dropdown, DropdownItem } from '../../ui/dropdown';
 import { Icon } from '../../ui/icon';
+import { FlexStack } from '../../layout/flex-stack';
 import css from './metrics-display-selector.module.css';
-import { FlexStack } from '../../layout';
-
-const DEFAULT_GROUP_BY = '';
 
 const METRICS_DISPLAY_MAP = {
   [MetricsDisplayType.TABLE]: {
@@ -35,7 +37,13 @@ export const MetricsDisplaySelector = (
   props: MetricsDisplaySelectorProps &
     Omit<React.ComponentProps<typeof ControlGroup>, 'onSelect' | 'value'>,
 ) => {
-  const { value, groupBy = DEFAULT_GROUP_BY, groups = {}, onSelect, ...restProps } = props;
+  const {
+    value,
+    groupBy = MetricsDisplayGroupByDefault,
+    groups = {},
+    onSelect,
+    ...restProps
+  } = props;
 
   return (
     <ControlGroup {...restProps}>
@@ -63,14 +71,14 @@ export const MetricsDisplaySelector = (
         }
 
         const displayGroupsData = [
-          {
-            value: DEFAULT_GROUP_BY,
-            label: 'No groups',
-          },
           ...displayGroups.map((displayGroup) => ({
             value: displayGroup,
             label: `Group by ${displayGroup}`,
           })),
+          {
+            value: MetricsDisplayGroupBy.NONE,
+            label: 'No group',
+          },
         ];
 
         return (

--- a/packages/ui/src/constants.ts
+++ b/packages/ui/src/constants.ts
@@ -46,6 +46,15 @@ export enum MetricsDisplayType {
   TREEMAP = 'treemap',
 }
 
+export const MetricsDisplayTypeDefault = MetricsDisplayType.TABLE;
+
+export enum MetricsDisplayGroupBy {
+  FOLDER = 'folder',
+  NONE = 'no-group',
+}
+
+export const MetricsDisplayGroupByDefault = MetricsDisplayGroupBy.FOLDER;
+
 export enum ModuleSizeMetric {
   SIZE = 'value',
   DUPLICATE_SIZE = 'duplicateSize',

--- a/packages/ui/src/hooks/metrics-display-type.ts
+++ b/packages/ui/src/hooks/metrics-display-type.ts
@@ -2,10 +2,10 @@ import { useCallback, useEffect, useMemo } from 'react';
 import { useLocalStorage } from 'react-use';
 import { StringParam, useQueryParams } from 'use-query-params';
 
-import { MetricsDisplayType } from '../constants';
+import { MetricsDisplayType, MetricsDisplayGroupBy } from '../constants';
 
 const DEFAULT_VALUE = MetricsDisplayType.TABLE;
-const DEFAULT_GROUP_BY = '';
+const GROUP_BY_DEFAULT = MetricsDisplayGroupBy.FOLDER;
 
 // Display type query param name
 const QUERY_PARAM_VALUE = 'dt';
@@ -36,7 +36,7 @@ export const useMetricsDisplayType = (
     'storage',
     {
       value: DEFAULT_VALUE,
-      groupBy: DEFAULT_GROUP_BY,
+      groupBy: GROUP_BY_DEFAULT,
     },
   );
 
@@ -64,11 +64,14 @@ export const useMetricsDisplayType = (
     const resolvedValue = queryParamGroupBy ?? localStorage?.groupBy;
 
     if (!resolvedValue) {
-      return DEFAULT_GROUP_BY;
+      return GROUP_BY_DEFAULT;
     }
 
-    if (!groups?.[value]?.includes(resolvedValue as MetricsDisplayType)) {
-      return DEFAULT_GROUP_BY;
+    if (
+      resolvedValue !== MetricsDisplayGroupBy.NONE &&
+      !groups?.[value]?.includes(resolvedValue as MetricsDisplayType)
+    ) {
+      return GROUP_BY_DEFAULT;
     }
 
     return resolvedValue;
@@ -93,7 +96,7 @@ export const useMetricsDisplayType = (
   }, [value, groupBy, setLocalStorage, localStorage]);
 
   const setDisplayType = useCallback(
-    (newValue: MetricsDisplayType, newGroupBy: string = DEFAULT_GROUP_BY) => {
+    (newValue: MetricsDisplayType, newGroupBy: string = GROUP_BY_DEFAULT) => {
       setQueryParams({
         [QUERY_PARAM_VALUE]: newValue,
         [QUERY_PARAM_GROUP_BY]: newGroupBy,

--- a/packages/ui/src/ui/dropdown/dropdown.tsx
+++ b/packages/ui/src/ui/dropdown/dropdown.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import cx from 'classnames';
-import { Menu, MenuButton, MenuItem, useMenuState } from 'ariakit/menu';
+import { Menu, MenuButton, MenuItem, MenuStateProps, useMenuState } from 'ariakit/menu';
 
 import { Button, BUTTON_SIZE } from '../button';
 import css from './dropdown.module.css';
@@ -23,6 +23,7 @@ interface DropdownProps {
   ariaLabel?: string;
   glyph?: string;
   disabled?: boolean;
+  placement?: MenuStateProps['placement'];
 }
 
 export const Dropdown = (props: DropdownProps & React.ComponentProps<'div'>) => {
@@ -33,11 +34,12 @@ export const Dropdown = (props: DropdownProps & React.ComponentProps<'div'>) => 
     ariaLabel = '',
     glyph = '',
     disabled = false,
+    placement,
     children,
   } = props;
 
   const dropdownAriaLabel = ariaLabel || (typeof label === 'string' ? label : '');
-  const menuState = useMenuState();
+  const menuState = useMenuState({ placement });
 
   return (
     <>


### PR DESCRIPTION
- resolves https://github.com/relative-ci/bundle-stats/issues/5019


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Expanded metrics display grouping options with a new “No group” selection for more flexible data presentation.
	- Dropdown menus now support adjustable placement, enhancing interaction and overall usability.
- **Style**
	- Refined dropdown and button visuals with improved hover, focus, and active state styling for a more polished interface.
- **Bug Fixes**
	- Improved handling of default grouping logic to ensure a defined group is used instead of an empty string.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->