### PR TITLE
Default display type to treemap

### DIFF
--- a/packages/ui/src/components/metrics-display-selector/metrics-display-selector.module.css
+++ b/packages/ui/src/components/metrics-display-selector/metrics-display-selector.module.css
@@ -9,8 +9,19 @@
 
 .dropdownGroupAnchor {
   border: none;
-  border-left: 1px solid var(--color-outline);
   border-radius: 0;
+  position: relative;
+}
+
+.dropdownGroupAnchor::before {
+  content: '';
+  display: block;
+  width: 1px;
+  background: var(--color-outline-dark);
+  position: absolute;
+  left: 0;
+  top: var(--space-xxxsmall);
+  bottom: var(--space-xxxsmall);
 }
 
 .dropdownGroupAnchor:hover,
@@ -31,6 +42,11 @@
 }
 
 /* explicit ControlGroup last item styles to override ariakit injected sibling nodes */
+.itemFirst {
+  border-top-left-radius: var(--radius-small) !important;
+  border-bottom-left-radius: var(--radius-small) !important;
+}
+
 .itemLast {
   border-top-right-radius: var(--radius-small) !important;
   border-bottom-right-radius: var(--radius-small) !important;

--- a/packages/ui/src/components/metrics-display-selector/metrics-display-selector.tsx
+++ b/packages/ui/src/components/metrics-display-selector/metrics-display-selector.tsx
@@ -50,6 +50,7 @@ export const MetricsDisplaySelector = (
       {displayTypes.map((displayType, index) => {
         const displayGroups = groups?.[displayType];
         const displayProps = METRICS_DISPLAY_MAP[displayType];
+        const isFirst = index === 0;
         const isLast = displayTypes.length - 1 === index;
         const isActive = displayType === value;
 
@@ -81,11 +82,15 @@ export const MetricsDisplaySelector = (
           },
         ];
 
+        const itemClassName = cx(
+          css.dropdownGroup,
+          isFirst && css.itemFirst,
+          isLast && css.itemLast,
+          isActive && css.itemActive,
+        );
+
         return (
-          <FlexStack
-            className={cx(css.dropdownGroup, isLast && css.itemLast, isActive && css.itemActive)}
-            key={displayType}
-          >
+          <FlexStack className={itemClassName} key={displayType}>
             <Button
               size="small"
               glyph={displayProps.glyph}

--- a/packages/ui/src/constants.ts
+++ b/packages/ui/src/constants.ts
@@ -42,8 +42,8 @@ export const SORT = {
 } as const;
 
 export enum MetricsDisplayType {
-  TABLE = 'table',
   TREEMAP = 'treemap',
+  TABLE = 'table',
 }
 
 export const MetricsDisplayTypeDefault = MetricsDisplayType.TABLE;

--- a/packages/ui/src/hooks/metrics-display-type.ts
+++ b/packages/ui/src/hooks/metrics-display-type.ts
@@ -4,7 +4,7 @@ import { StringParam, useQueryParams } from 'use-query-params';
 
 import { MetricsDisplayType, MetricsDisplayGroupBy } from '../constants';
 
-const DEFAULT_VALUE = MetricsDisplayType.TABLE;
+const DEFAULT_VALUE = MetricsDisplayType.TREEMAP;
 const GROUP_BY_DEFAULT = MetricsDisplayGroupBy.FOLDER;
 
 // Display type query param name

--- a/packages/ui/src/hooks/rows-sort.ts
+++ b/packages/ui/src/hooks/rows-sort.ts
@@ -50,7 +50,7 @@ interface UseRowsSort<TRow> {
 export const useRowsSort = <TRow>({
   rows,
   initialField = 'runs[0].delta',
-  initialDirection,
+  initialDirection = 'desc',
   getCustomSort,
   setQueryState,
 }: UseRowsSortParams<TRow>): UseRowsSort<TRow> => {


### PR DESCRIPTION
- **feat(ui): DisplayType - default to treemap**
- **feat(ui): TableMetrics - sort rows by delta desc**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved dropdown group item borders and radii for a more polished appearance in the metrics display selector.

- **New Features**
  - The metrics display selector now visually distinguishes the first item in the list for better clarity.

- **Refactor**
  - Updated internal logic for assigning class names to dropdown items, resulting in cleaner code.

- **Chores**
  - Changed the default metrics display type to "Treemap".
  - Set the default sort direction for rows to descending.
  - Reordered display type options for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->