### PR TITLE
fix(ui): Tooltip - revert dark background

### DIFF
--- a/packages/ui/src/ui/tooltip/tooltip.module.css
+++ b/packages/ui/src/ui/tooltip/tooltip.module.css
@@ -14,9 +14,9 @@
   z-index: var(--layer-xxhigh);
   padding: var(--space-xxxsmall) var(--space-xxsmall);
   border-radius: var(--radius-small);
-  background: var(--color-background);
+  background: var(--color-text);
   max-width: 28em;
-  color: var(--color-text-light);
+  color: var(--color-background);
   font-size: var(--size-small);
   text-align: center;
   filter: drop-shadow(var(--shadow-layer));
@@ -25,5 +25,5 @@
 
 .arrow svg {
   display: block;
-  fill: var(--color-highlight);
+  fill: var(--color-text);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated tooltip appearance with an inverted color scheme for background and text.
  - Changed the SVG arrow color to match the new tooltip text color.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->