### PR TITLE
build: Use relative-ci/agent-action@v3

### DIFF
--- a/.github/workflows/relative-ci.yaml
+++ b/.github/workflows/relative-ci.yaml
@@ -10,8 +10,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Send webpack stats to RelativeCI
-        uses: relative-ci/agent-action@v2.2.0
+      - name: Send webpack stats and build information to RelativeCI
+        uses: relative-ci/agent-action@v3.0.0-beta
         with:
           # RelativeCI project key
           key: ${{ secrets.RELATIVE_CI_KEY }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the GitHub Actions workflow to use a newer version of the RelativeCI agent.
  - Enhanced workflow step to send both webpack stats and build information to RelativeCI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->