### PR TITLE
chore: Bump bundle-stats to v3

### DIFF
--- a/.github/workflows/relative-ci.yaml
+++ b/.github/workflows/relative-ci.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Send webpack stats and build information to RelativeCI
-        uses: relative-ci/agent-action@v3.0.0-beta
+        uses: relative-ci/agent-action@v3
         with:
           # RelativeCI project key
           key: ${{ secrets.RELATIVE_CI_KEY }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the RelativeCI GitHub Actions workflow to use the stable version of the RelativeCI agent action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->