### PR TITLE
fix: Optional peer dependencies for rollup/webpack plugins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28761,7 +28761,16 @@
         "node": ">= 16.0"
       },
       "peerDependencies": {
-        "rollup": "^3.0.0 || ^4.0.0"
+        "rollup": "^3.0.0 || ^4.0.0",
+        "vite": "^5.0.0 || ^6.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
       }
     },
     "packages/ui": {
@@ -28869,7 +28878,16 @@
         "node": ">= 14.0"
       },
       "peerDependencies": {
+        "@rspack/core": "0.x || 1.x",
         "webpack": "^4.0.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rspack/core": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
       }
     },
     "packages/webpack-plugin/node_modules/isarray": {

--- a/packages/rollup-plugin/package.json
+++ b/packages/rollup-plugin/package.json
@@ -66,6 +66,15 @@
     "typescript": "5.8.3"
   },
   "peerDependencies": {
+    "vite": "^5.0.0 || ^6.0.0",
     "rollup": "^3.0.0 || ^4.0.0"
+  },
+  "peerDependenciesMeta": {
+    "vite": {
+      "optional": true
+    },
+    "rollup": {
+      "optional": true
+    }
   }
 }

--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -61,6 +61,15 @@
     "webpack": "5.99.9"
   },
   "peerDependencies": {
+    "@rspack/core": "0.x || 1.x",
     "webpack": "^4.0.0 || ^5.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@rspack/core": {
+      "optional": true
+    },
+    "webpack": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated compatibility declarations to include new optional peer dependencies for both rollup and webpack plugin packages.
  - Added support for optional usage of Vite, Rollup, @rspack/core, and Webpack as peer dependencies, improving flexibility for different build tool configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->