### PR TITLE
chore: Update rollup-plugin-webpack-stats to v2.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24666,9 +24666,9 @@
       }
     },
     "node_modules/rollup-plugin-webpack-stats": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-webpack-stats/-/rollup-plugin-webpack-stats-2.1.2.tgz",
-      "integrity": "sha512-2YN3hTQx90wvXo7VG9/s2qKECoA+BmBiMLj4UMbP00jt3giExQYN2mOXv5mwesB48Q5syGjFYfAa1nuN9TU1Aw==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-webpack-stats/-/rollup-plugin-webpack-stats-2.1.3.tgz",
+      "integrity": "sha512-OOhpuwwoxW8J5pVd+RdokSbaVa21/4/mV1EsBBLfmcmc2hjL5VMFkytN0YTFGfPWcluWBCxrpA+8SP7P3xvloQ==",
       "license": "MIT",
       "dependencies": {
         "rollup-plugin-stats": "1.5.0"
@@ -29048,7 +29048,7 @@
       "license": "MIT",
       "dependencies": {
         "@bundle-stats/cli-utils": "^4.21.1",
-        "rollup-plugin-webpack-stats": "2.1.2",
+        "rollup-plugin-webpack-stats": "2.1.3",
         "tslib": "2.8.1"
       },
       "devDependencies": {
@@ -29071,10 +29071,14 @@
         "node": ">= 16.0"
       },
       "peerDependencies": {
+        "rolldown": "^1.0.0-beta.0",
         "rollup": "^3.0.0 || ^4.0.0",
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
       },
       "peerDependenciesMeta": {
+        "rolldown": {
+          "optional": true
+        },
         "rollup": {
           "optional": true
         },

--- a/packages/rollup-plugin/package.json
+++ b/packages/rollup-plugin/package.json
@@ -46,7 +46,7 @@
   "homepage": "https://github.com/relative-ci/bundle-stats/blob/master/packages/rollup-plugin#readme",
   "dependencies": {
     "@bundle-stats/cli-utils": "^4.21.1",
-    "rollup-plugin-webpack-stats": "2.1.2",
+    "rollup-plugin-webpack-stats": "2.1.3",
     "tslib": "2.8.1"
   },
   "devDependencies": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a dependency to its latest version for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->