### PR TITLE
Enable OIDC publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,5 +303,4 @@ jobs:
 
       - run: npm run release
         env:
-          NPM_CONFIG_PROVENANCE: true
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Bumped versions to 4.21.4-beta.0 across packages (CLI, CLI Utils, UI, HTML Templates, Webpack Plugin, Rollup Plugin, Gatsby Plugin, Next Plugin, Plugin Webpack Filter, Plugin Webpack Validate, Utils).
  - Pinned internal dependencies to exact 4.21.4-beta.0 versions for consistency and predictable installs.
  - Updated CI publish configuration to simplify credentials (removed extra NPM-related env variables; GitHub token remains).
  - No user-facing feature changes or API modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->